### PR TITLE
Fix: Archive Story scenario can be restored properly

### DIFF
--- a/EpinelPS/LobbyServer/Archive/ArchiveClearStage.cs
+++ b/EpinelPS/LobbyServer/Archive/ArchiveClearStage.cs
@@ -10,8 +10,8 @@ namespace EpinelPS.LobbyServer.Archive
             ReqClearArchiveStage req = await ReadData<ReqClearArchiveStage>(); // has fields EventId, StageId, BattleResult
             int evid = req.EventId;
             int stgid = req.StageId;
-            int result = req.BattleResult; // if 2 add to event info as last stage
-            User user = GetUser() ?? throw new Exception("User not found.");
+            int result = req.BattleResult;
+            User user = GetUser();
 
             // Check if the EventInfo exists for the given EventId
             if (!user.EventInfo.TryGetValue(evid, out EventData? eventData))
@@ -19,13 +19,12 @@ namespace EpinelPS.LobbyServer.Archive
                 throw new Exception($"Event with ID {evid} not found.");
             }
 
-            // Update the EventData if BattleResult is 2
-            if (result == 1)
+            // Update the EventData if BattleResult is 1
+            if (result == 1 && !eventData.ClearedStages.Contains(stgid))
             {
-
+                eventData.ClearedStages.Add(stgid);
                 // Update the LastStage in EventData
                 eventData.LastStage = stgid;
-
             }
 			JsonDb.Save();
             ResClearArchiveStage response = new();

--- a/EpinelPS/LobbyServer/Archive/FastClearArchiveStage.cs
+++ b/EpinelPS/LobbyServer/Archive/FastClearArchiveStage.cs
@@ -11,16 +11,19 @@ namespace EpinelPS.LobbyServer.Archive
             int evid = req.EventId;
             int stgid = req.StageId;
 
-            User user = GetUser() ?? throw new Exception("User not found.");
+            User user = GetUser();
 
             // Check if the EventInfo exists for the given EventId
             if (!user.EventInfo.TryGetValue(evid, out EventData? eventData))
             {
                 throw new Exception($"Event with ID {evid} not found.");
             }
-            // Update the LastStage in EventData
-            eventData.LastStage = stgid;
-
+            if (!eventData.ClearedStages.Contains(stgid))
+            {
+                eventData.ClearedStages.Add(stgid);
+                // Update the LastStage in EventData
+                eventData.LastStage = stgid;
+            }
 			JsonDb.Save();
             ResFastClearArchiveStage response = new();
 

--- a/EpinelPS/LobbyServer/Archive/GetNonResettable.cs
+++ b/EpinelPS/LobbyServer/Archive/GetNonResettable.cs
@@ -1,7 +1,4 @@
 using EpinelPS.Utils;
-using EpinelPS.Data; // Ensure this namespace is included
-
-
 namespace EpinelPS.LobbyServer.Archive
 {
     [PacketPath("/archive/scenario/getnonresettable")]
@@ -9,41 +6,16 @@ namespace EpinelPS.LobbyServer.Archive
     {
         protected override async Task HandleAsync()
         {
-            ReqGetNonResettableArchiveScenario req = await ReadData<ReqGetNonResettableArchiveScenario>(); // req has EventId field
-            int evId = req.EventId;
+            ReqGetNonResettableArchiveScenario req = await ReadData<ReqGetNonResettableArchiveScenario>();
             ResGetNonResettableArchiveScenario response = new();
 
-            // Access the GameData instance
-            GameData gameData = GameData.Instance;
-
-            if (evId == 130002)
+            User user = GetUser();
+            foreach (var (evtId, evtData) in user.EventInfo)
             {
-                // Directly use the archiveEventQuestRecords dictionary
-                foreach (ArchiveEventQuestRecord_Raw record in gameData.archiveEventQuestRecords.Values)
+                if (evtId == req.EventId)
                 {
-                    if (record.EventQuestManagerId == evId)
-                    {
-                        // Add the end_scenario_Id to the ScenarioIdList
-                        if (!string.IsNullOrEmpty(record.EndScenarioId))
-                        {
-                            response.ScenarioIdList.Add(record.EndScenarioId);
-                        }
-                    }
-                }
-            }
-            else
-            {
-                // Directly use the archiveEventStoryRecords dictionary
-                foreach (ArchiveEventStoryRecord record in gameData.archiveEventStoryRecords.Values)
-                {
-                    if (record.EventId == evId)
-                    {
-                        // Add the PrologueScenario to the ScenarioIdList
-                        if (!string.IsNullOrEmpty(record.PrologueScenario))
-                        {
-                            response.ScenarioIdList.Add(record.PrologueScenario);
-                        }
-                    }
+                    response.ScenarioIdList.AddRange(evtData.CompletedScenarios);
+                    break;
                 }
             }
 

--- a/EpinelPS/LobbyServer/Archive/GetResettable.cs
+++ b/EpinelPS/LobbyServer/Archive/GetResettable.cs
@@ -10,11 +10,21 @@ namespace EpinelPS.LobbyServer.Archive
             ReqGetResettableArchiveScenario req = await ReadData<ReqGetResettableArchiveScenario>();
             ResGetResettableArchiveScenario response = new(); // has ScenarioIdList field that takes in strings
 
-            // Retrieve stage IDs from GameData
-            List<string> stageIds = [.. GameData.Instance.archiveEventDungeonStageRecords.Values.Select(record => record.StageId.ToString())];
-
-            // Add them to the response
-            response.ScenarioIdList.Add(stageIds);
+            GameData gameData = GameData.Instance;
+            User user = GetUser();
+            foreach (ArchiveEventStoryRecord record in gameData.archiveEventStoryRecords.Values)
+            {
+                // Add the PrologueScenario to the ScenarioIdList
+                if (record.EventId == req.EventId && !string.IsNullOrEmpty(record.PrologueScenario))
+                {
+                    if (user.EventInfo.TryGetValue(req.EventId, out EventData? evtData) &&
+                        evtData.CompletedScenarios.Contains(record.PrologueScenario))
+                    {
+                        response.ScenarioIdList.Add(record.PrologueScenario);
+                    }
+                    break;
+                }
+            }
 
             await WriteDataAsync(response);
         }

--- a/EpinelPS/LobbyServer/LobbyUser/GetUserScenarioExist.cs
+++ b/EpinelPS/LobbyServer/LobbyUser/GetUserScenarioExist.cs
@@ -1,5 +1,4 @@
 ﻿using EpinelPS.Utils;
-
 namespace EpinelPS.LobbyServer.LobbyUser
 {
     [PacketPath("/user/scenario/exist")]
@@ -13,21 +12,34 @@ namespace EpinelPS.LobbyServer.LobbyUser
 
             ResExistScenario response = new();
 
-            User user = GetUser();
-
             foreach (string? item in req.ScenarioGroupIds)
             {
-                foreach (string completed in user.CompletedScenarios)
+                if (FindScenarioInMainStages(item) || FindScenarioInArchiveStages(item))
                 {
-                    // story thingy was completed
-                    if (completed == item)
-                    {
-                        response.ExistGroupIds.Add(item);
-                    }
+                    response.ExistGroupIds.Add(item);
                 }
             }
 
             await WriteDataAsync(response);
+        }
+
+        private bool FindScenarioInMainStages(string scenarioGroupId)
+        {
+            User user = GetUser();
+            return user.CompletedScenarios.Contains(scenarioGroupId);
+        }
+
+        private bool FindScenarioInArchiveStages(string scenarioGroupId)
+        {
+            User user = GetUser();
+            foreach (EventData evtData in user.EventInfo.Values)
+            {
+                if (evtData.CompletedScenarios.Contains(scenarioGroupId))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fix the issue that the story progress of all the story events cannot be restored after restarting the game.

<img width="721" height="852" alt="image" src="https://github.com/user-attachments/assets/d59bc3b0-3092-4d2a-8227-29b037e385e0" />

The reason is on the `/archive/scenario/getresettable` and `/v1/archive/scenario/getnonresettable`. As far as I tested, the former needs to response the prologue id (if completed), and the latter needs all the completed scenarios in this event.

<img width="585" height="852" alt="image" src="https://github.com/user-attachments/assets/5250aca5-ec69-49a0-bfb2-72a9522b8c10" />
