### PR TITLE
Modify SetTeam logic

### DIFF
--- a/EpinelPS/LobbyServer/Team/SetTeam.cs
+++ b/EpinelPS/LobbyServer/Team/SetTeam.cs
@@ -1,4 +1,5 @@
-﻿using EpinelPS.Database;
+﻿using EpinelPS.Data;
+using EpinelPS.Database;
 using EpinelPS.Utils;
 
 namespace EpinelPS.LobbyServer.Team
@@ -16,10 +17,16 @@ namespace EpinelPS.LobbyServer.Team
             {
                 Type = req.Type
             };
-            response.Teams.AddRange(req.Teams.ToArray());
+            response.Teams.AddRange([.. req.Teams]);
 
             // Add team data to user data
-            NetUserTeamData teamData = new() { LastContentsTeamNumber = req.ContentsId + 1, Type = req.Type };
+            int contentsId = req.ContentsId + 1; // Default to 1 if not provided
+            if (req.Type == (int)TeamType.StoryEvent)
+            {
+                contentsId = 1; // Default to 1 for story event teams
+            }
+
+            NetUserTeamData teamData = new() { LastContentsTeamNumber = contentsId, Type = req.Type };
 
             // Check for existing teams with same TeamNumber and replace or add accordingly
             foreach (var newTeam in req.Teams)
@@ -47,7 +54,7 @@ namespace EpinelPS.LobbyServer.Team
             {
                 // If key already exists, we need to merge teams properly
                 var existingTeamData = user.UserTeams[req.Type];
-                existingTeamData.LastContentsTeamNumber = req.ContentsId + 1;
+                existingTeamData.LastContentsTeamNumber = contentsId;
                 existingTeamData.Type = req.Type;
 
                 // Apply same logic to existing team data


### PR DESCRIPTION
修改 SetTeam 逻辑中的ContentsId。修复活动stage无法进行的问题，如果db.json的UserTeams内已存在Type=20的Team且LastContentsTeamNumber!=1需要删除或者修改为1，重启游戏解决。
Fix the issue where the event stage could not proceed, if a Team with Type=20 already exists in UserTeams in db.json and LastContentsTeamNumber != 1, it needs to be deleted or changed to 1, and the game needs to be restarted.
<img width="999" height="977" alt="image" src="https://github.com/user-attachments/assets/61d3e25c-e8ab-41a9-b9f8-baf454a269e4" />



