### PR TITLE
feat: Implement SimRoom Overclock-实现模拟室超频

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,6 @@ dotnet_diagnostic.SYSLIB0039.severity = none
 
 # CS0219: 变量已被赋值，但从未使用过它的值
 dotnet_diagnostic.CS0219.severity = none
+
+# CS8618: 类型不包含 null 值的属性
+dotnet_diagnostic.CS8618.severity = none

--- a/EpinelPS/Data/GameData.cs
+++ b/EpinelPS/Data/GameData.cs
@@ -308,6 +308,16 @@ namespace EpinelPS.Data
         public readonly Dictionary<int, SimulationRoomBuffPreviewRecord> SimulationRoomBuffPreviewTable = [];
         [LoadRecord("SimulationRoomBuffTable.json", "Id")]
         public readonly Dictionary<int, SimulationRoomBuffRecord> SimulationRoomBuffTable = [];
+        
+        // SimulationRoom Overclock Data Tables
+        [LoadRecord("SimulationRoomOcLevelTable.json", "Id")]
+        public readonly Dictionary<int, SimulationRoomOverclockLevelRecord> SimulationRoomOcLevelTable = [];
+        [LoadRecord("SimulationRoomOcOptionGroupTable.json", "Id")]
+        public readonly Dictionary<int, SimulationRoomOverclockOptionGroupRecord> SimulationRoomOcOptionGroupTable = [];
+        [LoadRecord("SimulationRoomOcOptionTable.json", "Id")]
+        public readonly Dictionary<int, SimulationRoomOverclockOptionRecord> SimulationRoomOcOptionTable = [];
+        [LoadRecord("SimulationRoomOcSeasonTable.json", "Id")]
+        public readonly Dictionary<int, SimulationRoomOverclockSeasonRecord> SimulationRoomOcSeasonTable = [];
 
         static async Task<GameData> BuildAsync()
         {
@@ -350,8 +360,9 @@ namespace EpinelPS.Data
         {
             using FileStream fileStream = File.Open(file, FileMode.Open, FileAccess.Read);
 
-            Rfc2898DeriveBytes a = new(PresharedValue, data.GetSalt2Bytes(), 10000, HashAlgorithmName.SHA256);
-            byte[] key2 = a.GetBytes(32);
+            // Rfc2898DeriveBytes a = new(PresharedValue, data.GetSalt2Bytes(), 10000, HashAlgorithmName.SHA256);
+            // byte[] key2 = a.GetBytes(32);
+            byte[] key2 = Rfc2898DeriveBytes.Pbkdf2(PresharedValue, data.GetSalt2Bytes(), 10000, HashAlgorithmName.SHA256, 32);
 
             byte[] decryptionKey = key2[0..16];
             byte[] iv = key2[16..32];
@@ -387,8 +398,9 @@ namespace EpinelPS.Data
                 throw new Exception("error 3");
 
             dataMs.Position = 0;
-            Rfc2898DeriveBytes keyDec2 = new(PresharedValue, data.GetSalt1Bytes(), 10000, HashAlgorithmName.SHA256);
-            byte[] key3 = keyDec2.GetBytes(32);
+            // Rfc2898DeriveBytes keyDec2 = new(PresharedValue, data.GetSalt1Bytes(), 10000, HashAlgorithmName.SHA256);
+            // byte[] key3 = keyDec2.GetBytes(32);
+            byte[] key3 = Rfc2898DeriveBytes.Pbkdf2(PresharedValue, data.GetSalt1Bytes(), 10000, HashAlgorithmName.SHA256, 32);
 
             byte[] val2 = key3[0..16];
             byte[] iv2 = key3[16..32];

--- a/EpinelPS/LobbyServer/Character/GetCharacterData.cs
+++ b/EpinelPS/LobbyServer/Character/GetCharacterData.cs
@@ -13,7 +13,27 @@ namespace EpinelPS.LobbyServer.Character
             ResGetCharacterData response = new();
             foreach (CharacterModel item in user.Characters)
             {
-                response.Character.Add(new NetUserCharacterData() { Default = new() { Csn = item.Csn, Skill1Lv = item.Skill1Lvl, Skill2Lv = item.Skill2Lvl, CostumeId = item.CostumeId, Lv = user.GetCharacterLevel(item.Csn, item.Level), Grade = item.Grade, Tid = item.Tid, UltiSkillLv = item.UltimateLevel }, IsSynchro = user.GetSynchro(item.Csn) });
+                response.Character.Add(new NetUserCharacterData()
+                {
+                    Default = new()
+                    {
+                        Csn = item.Csn,
+                        Skill1Lv = item.Skill1Lvl,
+                        Skill2Lv = item.Skill2Lvl,
+                        CostumeId = item.CostumeId,
+                        Lv = user.GetCharacterLevel(item.Csn, item.Level),
+                        Grade = item.Grade,
+                        Tid = item.Tid,
+                        UltiSkillLv = item.UltimateLevel
+                    },
+                    IsSynchro = user.GetSynchro(item.Csn)
+                });
+                
+                // Check if character is main force
+                if (item.IsMainForce)
+                {
+                    response.MainForceCsnList.Add(item.Csn);
+                }
             }
 
             List<CharacterModel> highestLevelCharacters = [.. user.Characters.OrderByDescending(x => x.Level).Take(5)];

--- a/EpinelPS/LobbyServer/Character/SetCharacterMainForce.cs
+++ b/EpinelPS/LobbyServer/Character/SetCharacterMainForce.cs
@@ -1,0 +1,29 @@
+﻿using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Character
+{
+    [PacketPath("/character/mainforce/set")]
+    public class SetCharacterMainForce : LobbyMsgHandler
+    {
+        protected override async Task HandleAsync()
+        {
+            ReqSetCharacterMainForce req = await ReadData<ReqSetCharacterMainForce>();
+            User user = GetUser();
+
+            foreach (CharacterModel item in user.Characters)
+            {
+                if (item.Csn == req.Csn)
+                {
+                    item.IsMainForce = req.IsMainForce;
+                    break;
+                }
+            }
+            JsonDb.Save();
+
+            ResSetCharacterMainForce response = new();
+
+            await WriteDataAsync(response);
+        }
+    }
+}

--- a/EpinelPS/LobbyServer/ContentsOpen/GetUnlocked.cs
+++ b/EpinelPS/LobbyServer/ContentsOpen/GetUnlocked.cs
@@ -31,7 +31,7 @@ namespace EpinelPS.LobbyServer.ContentsOpen
                 JsonDb.Save();
             }
 
-            foreach (KeyValuePair<int, UnlockData> item in user.ContentsOpenUnlocked)
+            foreach (KeyValuePair<int, UnlockData> item in user.ContentsOpenUnlocked.OrderBy(x => x.Key))
             {
                 response.ContentsOpenUnlockInfoList.Add(new NetContentsOpenUnlockInfo()
                 {

--- a/EpinelPS/LobbyServer/LobbyUser/GetUserTitleCounter.cs
+++ b/EpinelPS/LobbyServer/LobbyUser/GetUserTitleCounter.cs
@@ -7,11 +7,16 @@ namespace EpinelPS.LobbyServer.LobbyUser
     {
         protected override async Task HandleAsync()
         {
-            ReqGetUserTitleCounterList req = await ReadData<ReqGetUserTitleCounterList>();
+            await ReadData<ReqGetUserTitleCounterList>();
 
-            ResGetUserTitleCounterList r = new();
+            ResGetUserTitleCounterList response = new();
+            response.UserTitleCounterList.Add(new ResGetUserTitleCounterList.Types.NetUserTitleCounter { Condition = 23, SubCondition = 1, Count = 10});
+            response.UserTitleCounterList.Add(new ResGetUserTitleCounterList.Types.NetUserTitleCounter { Condition = 23, SubCondition = 2, Count = 10});
+            response.UserTitleCounterList.Add(new ResGetUserTitleCounterList.Types.NetUserTitleCounter { Condition = 23, SubCondition = 3, Count = 10});
+            response.UserTitleCounterList.Add(new ResGetUserTitleCounterList.Types.NetUserTitleCounter { Condition = 23, SubCondition = 4, Count = 10});
+            response.UserTitleCounterList.Add(new ResGetUserTitleCounterList.Types.NetUserTitleCounter { Condition = 23, SubCondition = 5, Count = 10});
 
-            await WriteDataAsync(r);
+            await WriteDataAsync(response);
         }
     }
 }

--- a/EpinelPS/LobbyServer/Simroom/GetAcquireBuffFunction.cs
+++ b/EpinelPS/LobbyServer/Simroom/GetAcquireBuffFunction.cs
@@ -1,0 +1,44 @@
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Simroom
+{
+    [PacketPath("/simroom/getacquirebufffunction")]
+    public class GetAcquireBuffFunction : LobbyMsgHandler
+    {
+        protected override async Task HandleAsync()
+        {
+            // ReqGetSimRoomAcquireBuffFunction Fields
+            //  NetSimRoomEventLocationInfo Location
+            //  int Event
+            //  int SelectionNumber
+            //  int SelectionGroupElementId
+            // { "location": { "chapter": 3, "stage": 6, "order": 2 }, "event": 22103, "selectionNumber": 2, "selectionGroupElementId": 221033 }
+            var req = await ReadData<ReqGetSimRoomAcquireBuffFunction>();
+            var user = GetUser();
+
+            // ResGetSimRoomAcquireBuffFunction Fields
+            //  SimRoomResult Result
+            //  int RandomBuff
+            ResGetSimRoomAcquireBuffFunction response = new()
+            {
+                Result = SimRoomResult.Success,
+                RandomBuff = 2020406
+            };
+            // Update 
+            var location = req.Location;
+            // Check
+            var events = user.ResetableData.SimRoomData.Events;
+            var simRoomEventIndex = events.FindIndex(x => x.Location.Chapter == location.Chapter && x.Location.Stage == location.Stage && x.Location.Order == location.Order);
+            if (simRoomEventIndex < 0)
+            {
+                Logging.Warn("Not Fond UserSimRoomEvent");
+                await WriteDataAsync(response);
+            }
+            SimRoomHelper.UpdateUserSimRoomEvent(user, index: simRoomEventIndex, events: events, selectionNumber: req.SelectionNumber, isDone: true);
+            JsonDb.Save();
+
+            await WriteDataAsync(response);
+        }
+    }
+}

--- a/EpinelPS/LobbyServer/Simroom/InfinitePopupCheck.cs
+++ b/EpinelPS/LobbyServer/Simroom/InfinitePopupCheck.cs
@@ -1,0 +1,22 @@
+using EpinelPS.Database;
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Simroom
+{
+    [PacketPath("/simroom/popup-check/infinite")]
+    public class InfinitePopupCheck : LobbyMsgHandler
+    {
+        protected override async Task HandleAsync()
+        {
+            await ReadData<ReqInfinitePopupCheck>();
+            var user = GetUser();
+
+            ResInfinitePopupCheck response = new();
+
+            user.ResetableData.SimRoomData.CurrentSeasonData.WasInfinitePopupChecked = true;
+            JsonDb.Save();
+
+            await WriteDataAsync(response);
+        }
+    }
+}

--- a/EpinelPS/LobbyServer/Simroom/ProceedSkipFunction.cs
+++ b/EpinelPS/LobbyServer/Simroom/ProceedSkipFunction.cs
@@ -1,0 +1,40 @@
+using EpinelPS.Utils;
+
+namespace EpinelPS.LobbyServer.Simroom
+{
+    [PacketPath("/simroom/proceedskipfunction")]
+    public class ProceedSkipFunction : LobbyMsgHandler
+    {
+        protected override async Task HandleAsync()
+        {
+            //  { "location": { "chapter": 3, "stage": 6, "order": 2 }, "event": 21060, "selectionNumber": 2, "selectionGroupElementId": 210602 }
+            var req = await ReadData<ReqProceedSimRoomSkipFunction>();
+            // ReqProceedSimRoomSkipFunction Fields
+            //  NetSimRoomEventLocationInfo location,
+            //  int event,
+            //  int selectionNumber, 
+            //  int selectionGroupElementId,
+            User user = GetUser();
+            // ResProceedSimRoomSkipFunction Fields
+            //  SimRoomResult Result,
+            ResProceedSimRoomSkipFunction response = new()
+            {
+                Result = SimRoomResult.Success
+            };
+
+            // Update 
+            var location = req.Location;
+            // Check
+            var events = user.ResetableData.SimRoomData.Events;
+            var simRoomEventIndex = events.FindIndex(x => x.Location.Chapter == location.Chapter && x.Location.Stage == location.Stage && x.Location.Order == location.Order);
+            if (simRoomEventIndex < 0)
+            {
+                Logging.Warn("Not Fond UserSimRoomEvent");
+                await WriteDataAsync(response);
+            }
+            SimRoomHelper.UpdateUserSimRoomEvent(user, index: simRoomEventIndex, events: events, selectionNumber: req.SelectionNumber, isDone: true);
+
+            await WriteDataAsync(response);
+        }
+    }
+}

--- a/EpinelPS/LobbyServer/Simroom/Quit.cs
+++ b/EpinelPS/LobbyServer/Simroom/Quit.cs
@@ -45,6 +45,7 @@ namespace EpinelPS.LobbyServer.Simroom
             user.ResetableData.SimRoomData.Events = [];
             user.ResetableData.SimRoomData.RemainingHps = [];
             user.ResetableData.SimRoomData.Buffs = [];
+            user.ResetableData.SimRoomData.CurrentSeasonData.IsOverclock = false;
 
             JsonDb.Save();
 

--- a/EpinelPS/LobbyServer/Simroom/SelectBuff.cs
+++ b/EpinelPS/LobbyServer/Simroom/SelectBuff.cs
@@ -60,6 +60,12 @@ namespace EpinelPS.LobbyServer.Simroom
                         var difficulty = user.ResetableData.SimRoomData.CurrentDifficulty;
                         var reward = SimRoomHelper.SimRoomReceivedReward(user, difficulty, location.Chapter);
                         if (reward is not null) response.Reward = reward;
+
+                        var overclockReward = SimRoomHelper.SimRoomOverclockReceivedReward(user);
+                        if (overclockReward is not null) response.RewardByOverclock = overclockReward;
+
+                        // Update User OverclockHighScoreData
+                        SimRoomHelper.UpdateOverclockHighScoreData(user, req.Location);
                     }
                 }
 

--- a/EpinelPS/LobbyServer/Simroom/SelectDifficulty.cs
+++ b/EpinelPS/LobbyServer/Simroom/SelectDifficulty.cs
@@ -20,9 +20,22 @@ namespace EpinelPS.LobbyServer.Simroom
             user.ResetableData.SimRoomData.Entered = true;
             user.ResetableData.SimRoomData.CurrentDifficulty = req.Difficulty;
             user.ResetableData.SimRoomData.CurrentChapter = req.StartingChapter;
+            // Update season data
+            bool isOverclock = req.OverclockOptionList is not null && req.OverclockOptionList.Count > 0 && req.OverclockSeason > 0 && req.OverclockSubSeason > 0;
+            var currentSeasonData = user.ResetableData.SimRoomData.CurrentSeasonData;
+            currentSeasonData.IsOverclock = isOverclock;
+            if (isOverclock)
+            { 
+                currentSeasonData.CurrentSeason = req.OverclockSeason;
+                currentSeasonData.CurrentSubSeason = req.OverclockSubSeason;
+                currentSeasonData.CurrentOptionList = [.. req.OverclockOptionList];
+            }
+            user.ResetableData.SimRoomData.CurrentSeasonData = currentSeasonData;
             JsonDb.Save();
 
-            List<NetSimRoomEvent> events = SimRoomHelper.GetSimRoomEvents(user);
+            List<NetSimRoomEvent> events = SimRoomHelper.GetSimRoomEvents(user, req.Difficulty, req.StartingChapter,
+             [.. req.OverclockOptionList], req.OverclockSeason, req.OverclockSubSeason);
+             
             user.ResetableData.SimRoomData.Events = [.. events.Select(SimRoomHelper.NetToM)];
             JsonDb.Save();
             

--- a/EpinelPS/LobbyServer/Team/SetTeam.cs
+++ b/EpinelPS/LobbyServer/Team/SetTeam.cs
@@ -1,5 +1,4 @@
-﻿using EpinelPS.Data;
-using EpinelPS.Database;
+﻿using EpinelPS.Database;
 using EpinelPS.Utils;
 
 namespace EpinelPS.LobbyServer.Team
@@ -21,9 +20,10 @@ namespace EpinelPS.LobbyServer.Team
 
             // Add team data to user data
             int contentsId = req.ContentsId + 1; // Default to 1 if not provided
-            if (req.Type == (int)TeamType.StoryEvent)
+            
+            if (req.Teams.Count != 0)
             {
-                contentsId = 1; // Default to 1 for story event teams
+                contentsId = req.Teams.Select(x => x.TeamNumber).Max(x => x);
             }
 
             NetUserTeamData teamData = new() { LastContentsTeamNumber = contentsId, Type = req.Type };

--- a/EpinelPS/Models/DbModels.cs
+++ b/EpinelPS/Models/DbModels.cs
@@ -38,6 +38,7 @@ namespace EpinelPS.Models
         public int Skill1Lvl = 1;
         public int Skill2Lvl = 1;
         public int Grade = 0;
+        public bool IsMainForce = false;
     }
     public class MainQuestData
     {
@@ -128,6 +129,29 @@ namespace EpinelPS.Models
         public List<SimRoomChapterInfo> ReceivedRewardChapters = [];
         public bool IsSimpleModeSkipEnabled = false;
         public bool Entered = false;
+        public OverclockData CurrentSeasonData = new();
+    }
+    public class OverclockData
+    {
+        public int CurrentSeason;
+        public int CurrentSubSeason;
+        public List<int> CurrentOptionList = [];
+        public bool IsOverclock = false;
+        public bool HasClearedLevel50 = false;
+        public bool WasInfinitePopupChecked = false;
+        public bool WasMainSeasonResetPopupChecked = true;
+        public bool WasSubSeasonResetPopupChecked = true;
+        public OverclockHighScoreData CurrentSeasonHighScore = new();
+        public OverclockHighScoreData CurrentSubSeasonHighScore = new();
+        public OverclockHighScoreData LatestOption = new();
+    }
+    public class OverclockHighScoreData
+    {
+        public int Season;
+        public int SubSeason;
+        public List<int> OptionList = [];
+        public int OptionLevel;
+        public Google.Protobuf.WellKnownTypes.Timestamp? CreatedAt;
     }
     public class SimRoomEvent
     {

--- a/EpinelPS/Models/UserModel.cs
+++ b/EpinelPS/Models/UserModel.cs
@@ -460,7 +460,10 @@ public class User
             {
                 SimRoomData = new()
                 {
-                    LegacyBuffs = ResetableData.SimRoomData.LegacyBuffs // Retain old LegacyBuffs data
+                    LegacyBuffs = ResetableData.SimRoomData.LegacyBuffs, // Retain old LegacyBuffs data
+                    CurrentDifficulty = ResetableData.SimRoomData.CurrentDifficulty,
+                    CurrentChapter = ResetableData.SimRoomData.CurrentChapter,
+                    CurrentSeasonData = ResetableData.SimRoomData.CurrentSeasonData,
                 }
             };
             needsSave = true;
@@ -472,7 +475,18 @@ public class User
             Logging.WriteLine("Resetting weekly user data...", LogType.Warning);
 
             LastWeeklyReset = DateTime.UtcNow;
-            ResetableData = new();
+            var currentSeasonData = ResetableData.SimRoomData.CurrentSeasonData;
+            currentSeasonData.LatestOption = new();
+            ResetableData = new()
+            {
+                SimRoomData = new()
+                {
+                    // Retain old LegacyBuffs data and currentSeason data
+                    CurrentDifficulty = ResetableData.SimRoomData.CurrentDifficulty,
+                    CurrentChapter = ResetableData.SimRoomData.CurrentChapter,
+                    CurrentSeasonData = currentSeasonData,
+                }
+            };
             needsSave = true;
         }
 


### PR DESCRIPTION
- Added GetAcquireBuffFunction to handle buff acquisition requests in the simulation room.
- Added InfinitePopupCheck to manage infinite popup checks for users.
- Added ProceedSkipFunction to process skip requests in the simulation room.
- Updated SelectDifficulty to handle overclock options and season data.
- Enhanced SimRoomHelper to support overclock mechanics and event group logic.
- Modified GetSimRoomData to include buffs and legacy buffs in the response.
- Updated Quit functionality to reset overclock state upon quitting the simulation room.
- Added logic to handle overclock rewards and high score updates.
- Refactored user model to retain current season data and legacy buffs during resets.
- Introduced new OverclockData and OverclockHighScoreData models to manage overclock states.